### PR TITLE
Fix - new song ID format

### DIFF
--- a/SyncSaberService/SyncSaber.cs
+++ b/SyncSaberService/SyncSaber.cs
@@ -105,7 +105,8 @@ namespace SyncSaberService
                 return;
             }
             string[] customSongDirectories = Directory.GetDirectories(CustomSongsPath);
-            string id = songIndex.Substring(0, songIndex.IndexOf("-"));
+            //string id = songIndex.Substring(0, songIndex.IndexOf("-"));
+            string id = songIndex;
             string version = songIndex.Substring(songIndex.IndexOf("-") + 1);
             foreach (string directory in customSongDirectories)
             {

--- a/SyncSaberService/Web/BeastSaberReader.cs
+++ b/SyncSaberService/Web/BeastSaberReader.cs
@@ -194,6 +194,10 @@ namespace SyncSaberService.Web
                         string songIndex = innerText.Substring(innerText.LastIndexOf('/') + 1);
                         string mapper = GetMapperFromBsaber(node.InnerText);
                         string songUrl = "https://beatsaver.com/download/" + songIndex;
+
+                        songIndex = node["SongKey"].InnerText;
+                        songUrl = "https://beatsaver.com/api/download/key/" + songIndex;
+
                         SongInfo currentSong = new SongInfo(songIndex, songName, songUrl, mapper);
                         //string currentSongDirectory = Path.Combine(Config.BeatSaberPath, "CustomSongs", songIndex);
                         //bool downloadFailed = false;

--- a/SyncSaberService/Web/DownloadJob.cs
+++ b/SyncSaberService/Web/DownloadJob.cs
@@ -18,7 +18,8 @@ namespace SyncSaberService.Web
     public class DownloadJob
     {
         public const string NOTFOUNDERROR = "The remote server returned an error: (404) Not Found.";
-        public const string BEATSAVER_DOWNLOAD_URL_BASE = "https://beatsaver.com/download/";
+        // public const string BEATSAVER_DOWNLOAD_URL_BASE = "https://beatsaver.com/download/";
+        public const string BEATSAVER_DOWNLOAD_URL_BASE = " https://beatsaver.com/api/download/key/";
         private const string TIMEOUTERROR = "The request was aborted: The request was canceled.";
 
         public enum JobResult


### PR DESCRIPTION
- Changed BEATSAVER_DOWNLOAD_URL_BASE to the new download endpoint
- songIndex is now just a direct copy from SongKey node.

This fix preserves the original variable declaration and defaults to help track changes, so some cleanup is necessary later.

Here's hoping I didn't messed up the code too much. =)