### PR TITLE
Fix - new song ID format

### DIFF
--- a/SyncSaberService/Data/SongInfo.cs
+++ b/SyncSaberService/Data/SongInfo.cs
@@ -270,15 +270,14 @@ namespace SyncSaberService.Data
             }
         }
         [JsonProperty("id")]
-        private int _id;
         [JsonIgnore]
-        public int id
+        public string id
         {
             get
             {
-                if (!(_id > 0))
-                    if (key != null && _beatSaverRegex.IsMatch(key))
-                        _id = int.Parse(key.Substring(0, key.IndexOf('-')));
+                if (_id == null)
+                    if (key != null)
+                        _id = key;
                 return _id;
             }
             set { _id = value; }

--- a/SyncSaberService/SyncSaber.cs
+++ b/SyncSaberService/SyncSaber.cs
@@ -170,7 +170,7 @@ namespace SyncSaberService
             }
             var reader = FeedReaders[feedType];
             DateTime startTime = DateTime.Now;
-            Dictionary<int, SongInfo> songs;
+            Dictionary<string, SongInfo> songs;
             List<Playlist> playlists = new List<Playlist>();
             playlists.Add(_syncSaberSongs);
             playlists.AddRange(reader.PlaylistsForFeed(_settings.FeedIndex));
@@ -238,7 +238,7 @@ namespace SyncSaberService
         /// <param name="skippedsongs"></param>
         /// <param name="useSongKeyAsOutputFolder"></param>
         /// <returns></returns>
-        public List<SongInfo> DownloadSongs(Dictionary<int, SongInfo> queuedSongs, out int skippedsongs, bool useSongKeyAsOutputFolder)
+        public List<SongInfo> DownloadSongs(Dictionary<string, SongInfo> queuedSongs, out int skippedsongs, bool useSongKeyAsOutputFolder)
         {
             //var existingSongs = Directory.GetDirectories(CustomSongsPath);
             string tempPath = "";

--- a/SyncSaberService/SyncSaber.cs
+++ b/SyncSaberService/SyncSaber.cs
@@ -105,7 +105,8 @@ namespace SyncSaberService
                 return;
             }
             string[] customSongDirectories = Directory.GetDirectories(CustomSongsPath);
-            string id = songIndex.Substring(0, songIndex.IndexOf("-"));
+            //string id = songIndex.Substring(0, songIndex.IndexOf("-"));
+            string id = songIndex;
             string version = songIndex.Substring(songIndex.IndexOf("-") + 1);
             foreach (string directory in customSongDirectories)
             {

--- a/SyncSaberService/Web/BeastSaberReader.cs
+++ b/SyncSaberService/Web/BeastSaberReader.cs
@@ -248,7 +248,7 @@ namespace SyncSaberService.Web
         /// <param name="settings"></param>
         /// <exception cref="InvalidCastException">Thrown when the passed IFeedSettings isn't a BeastSaberFeedSettings</exception>
         /// <returns></returns>
-        public Dictionary<int, SongInfo> GetSongsFromFeed(IFeedSettings settings)
+        public Dictionary<string, SongInfo> GetSongsFromFeed(IFeedSettings settings)
         {
             PrepareReader();
             BeastSaberFeedSettings _settings = settings as BeastSaberFeedSettings;
@@ -257,7 +257,7 @@ namespace SyncSaberService.Web
             if (_settings.FeedIndex != 2 && _username == string.Empty)
             {
                 Logger.Error($"Can't access feed without a valid username and password in the config file");
-                return new Dictionary<int, SongInfo>();
+                return new Dictionary<string, SongInfo>();
             }
             int pageIndex = 0;
             ConcurrentQueue<SongInfo> songList = new ConcurrentQueue<SongInfo>();
@@ -324,7 +324,7 @@ namespace SyncSaberService.Web
             actionBlock.Completion.Wait();
 
             Logger.Info($"Finished checking pages, found {songList.Count} songs");
-            Dictionary<int, SongInfo> retDict = new Dictionary<int, SongInfo>();
+            Dictionary<string, SongInfo> retDict = new Dictionary<string, SongInfo>();
             foreach (var song in songList)
             {
                 if (retDict.ContainsKey(song.id))

--- a/SyncSaberService/Web/BeastSaberReader.cs
+++ b/SyncSaberService/Web/BeastSaberReader.cs
@@ -194,6 +194,10 @@ namespace SyncSaberService.Web
                         string songIndex = innerText.Substring(innerText.LastIndexOf('/') + 1);
                         string mapper = GetMapperFromBsaber(node.InnerText);
                         string songUrl = "https://beatsaver.com/download/" + songIndex;
+
+                        songIndex = node["SongKey"].InnerText;
+                        songUrl = "https://beatsaver.com/api/download/key/" + songIndex;
+
                         SongInfo currentSong = new SongInfo(songIndex, songName, songUrl, mapper);
                         //string currentSongDirectory = Path.Combine(Config.BeatSaberPath, "CustomSongs", songIndex);
                         //bool downloadFailed = false;

--- a/SyncSaberService/Web/BeatSaverReader.cs
+++ b/SyncSaberService/Web/BeatSaverReader.cs
@@ -90,7 +90,7 @@ namespace SyncSaberService.Web
         /// <param name="_settings"></param>
         /// <exception cref="InvalidCastException">Thrown when the passed IFeedSettings isn't a BeatSaverFeedSettings</exception>
         /// <returns></returns>
-        public Dictionary<int, SongInfo> GetSongsFromFeed(IFeedSettings _settings)
+        public Dictionary<string, SongInfo> GetSongsFromFeed(IFeedSettings _settings)
         {
             PrepareReader();
             if (!(_settings is BeatSaverFeedSettings settings))
@@ -117,7 +117,7 @@ namespace SyncSaberService.Web
                     break;
             }
 
-            Dictionary<int, SongInfo> retDict = new Dictionary<int, SongInfo>();
+            Dictionary<string, SongInfo> retDict = new Dictionary<string, SongInfo>();
             foreach (var song in songs)
             {
                 if (retDict.ContainsKey(song.id))

--- a/SyncSaberService/Web/DownloadJob.cs
+++ b/SyncSaberService/Web/DownloadJob.cs
@@ -18,7 +18,8 @@ namespace SyncSaberService.Web
     public class DownloadJob
     {
         public const string NOTFOUNDERROR = "The remote server returned an error: (404) Not Found.";
-        public const string BEATSAVER_DOWNLOAD_URL_BASE = "https://beatsaver.com/download/";
+        // public const string BEATSAVER_DOWNLOAD_URL_BASE = "https://beatsaver.com/download/";
+        public const string BEATSAVER_DOWNLOAD_URL_BASE = " https://beatsaver.com/api/download/key/";
         private const string TIMEOUTERROR = "The request was aborted: The request was canceled.";
 
         public enum JobResult

--- a/SyncSaberService/Web/IFeedReader.cs
+++ b/SyncSaberService/Web/IFeedReader.cs
@@ -11,7 +11,7 @@ namespace SyncSaberService.Web
         void PrepareReader();
         List<SongInfo> GetSongsFromPage(string pageText);
         //Dictionary<int, FeedInfo> Feeds { get; }
-        Dictionary<int, SongInfo> GetSongsFromFeed(IFeedSettings settings);
+        Dictionary<string, SongInfo> GetSongsFromFeed(IFeedSettings settings);
         Playlist[] PlaylistsForFeed(int feedIndex);
     }
 

--- a/SyncSaberService/Web/ScoreSaberReader.cs
+++ b/SyncSaberService/Web/ScoreSaberReader.cs
@@ -71,7 +71,7 @@ namespace SyncSaberService.Web
             }
         }
 
-        public Dictionary<int, SongInfo> GetSongsFromFeed(IFeedSettings _settings)
+        public Dictionary<string, SongInfo> GetSongsFromFeed(IFeedSettings _settings)
         {
             PrepareReader();
             if (!(_settings is ScoreSaberFeedSettings settings))
@@ -88,7 +88,7 @@ namespace SyncSaberService.Web
                     break;
             }
 
-            Dictionary<int, SongInfo> retDict = new Dictionary<int, SongInfo>();
+            Dictionary<string, SongInfo> retDict = new Dictionary<string, SongInfo>();
             foreach (var song in songs)
             {
                 if (retDict.ContainsKey(song.id))


### PR DESCRIPTION
- Changed `BEATSAVER_DOWNLOAD_URL_BASE `to the new download endpoint
- `songIndex` now receives a direct copy from `SongKey` node.
- Changed `SongVersion.id` from `int `to `string`; propagated change to all related dictionaries.

This fix preserves the original variable declaration and defaults to help track changes, so some cleanup is necessary later.

Some Ids are returning 404s when download is attempted. Example:

https://bsaber.com/songs/555/
https://beatsaver.com/api/download/key/555

(I suppose this is related to a stale sync between the two services.)

Here's hoping I didn't messed up the code too much. =)